### PR TITLE
improve error handling: don't swallow the error message

### DIFF
--- a/src/share-file.android.ts
+++ b/src/share-file.android.ts
@@ -23,7 +23,7 @@ export class ShareFile {
         Application.android.foregroundActivity.startActivity(android.content.Intent.createChooser(intent, args.intentTitle ? args.intentTitle : 'Open file:'));
       }
       catch (e) {
-        console.log('ShareFile: Android intent failed');
+        console.log('ShareFile: Android intent failed: ' + e);
       }
     } else {
       console.log('ShareFile: Please add a file path');


### PR DESCRIPTION
Improvement for Error handling: don't swallow the actual arror but include it in console.log

(this helped us to understand the reason for the "  JS: ShareFile: Android intent failed" message ;)
